### PR TITLE
Add DOI badge

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,7 +29,7 @@ identifiers:
     value: "https://github.com/Imageomics/TreeOfLife-toolbox/releases/tag/v0.4.0-beta"
   - description: "The GitHub URL of the commit tagged with v0.4.0-beta."
     type: url
-    value: "https://github.com/Imageomics/TreeOfLife-toolbox/tree1b83015f18dc43fb16521b9ade42c49272a3f4a2"
+    value: "https://github.com/Imageomics/TreeOfLife-toolbox/tree/1b83015f18dc43fb16521b9ade42c49272a3f4a2"
 abstract: >-
   A tool for processing datasets that were downloaded using the distributed-downloader package, 
   specifically used for constructing the TreeOfLife-200M dataset.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,7 +29,7 @@ identifiers:
     value: "https://github.com/Imageomics/TreeOfLife-toolbox/releases/tag/v0.4.0-beta"
   - description: "The GitHub URL of the commit tagged with v0.4.0-beta."
     type: url
-    value: "https://github.com/Imageomics/TreeOfLife-toolbox/tree/<commit-hash>" # update post release
+    value: "https://github.com/Imageomics/TreeOfLife-toolbox/tree1b83015f18dc43fb16521b9ade42c49272a3f4a2"
 abstract: >-
   A tool for processing datasets that were downloaded using the distributed-downloader package, 
   specifically used for constructing the TreeOfLife-200M dataset.
@@ -50,4 +50,4 @@ keywords:
 license: MIT
 version: 0.4.0-beta
 date-released: '2025-11-14'
-# doi: Add Version-agnostic DOI post-release
+doi: "10.5281/zenodo.17612630"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tools for TreeOfLife dataset
+# Tools for TreeOfLife dataset [![DOI](https://zenodo.org/badge/933844468.svg)](https://doi.org/10.5281/zenodo.17612630)
 
 This repository contains tools used in creating the [TreeOfLife-200M dataset](https://huggingface.co/datasets/imageomics/TreeOfLife-200M). They were created on the basis of [distributed-downloader](https://github.com/Imageomics/distributed-downloader), which was used for downloading all the images. Step-by-step instructions to download all of the images are provided in [docs/README](docs/README.md#treeoflife200m-dataset-download-guide).
 
@@ -124,17 +124,18 @@ If using the [TreeOfLife-200M dataset](https://huggingface.co/datasets/imageomic
   title = {{TreeOfLife-toolbox}},
   url = {https://github.com/Imageomics/TreeOfLife-toolbox},
   version = {0.4.0-beta},
-  year = {2025}
+  year = {2025},
+  doi = {10.5281/zenodo.17612630}
 }
 ```
 
 ```
 @dataset{treeoflife_200m,
-  title = {{T}ree{O}f{L}ife-200{M}}, 
+  title = {{T}ree{O}f{L}ife-200{M} (Revision a8f38b4)}, 
   author = {Jianyang Gu and Samuel Stevens and Elizabeth G Campolongo and Matthew J Thompson and Net Zhang and Jiaman Wu and Andrei Kopanev and Zheda Mai and Alexander E. White and James Balhoff and Wasila M Dahdul and Daniel Rubenstein and Hilmar Lapp and Tanya Berger-Wolf and Wei-Lun Chao and Yu Su},
   year = {2025},
   url = {https://huggingface.co/datasets/imageomics/TreeOfLife-200M},
-  doi = {},
+  doi = {10.57967/hf/6786},
   publisher = {Hugging Face}
 }
 ```


### PR DESCRIPTION
Updated citation notes with DOI, for TOL-200M too. We may want to consider removing/changing this to at least point to a single source. It's not directly relevant to this repo and can be a pain to maintain (especially since TOL-200M doesn't have a version-agnostic DOI).

Also added release commit hash and version-agnostic DOI to citation file.